### PR TITLE
Add `data_pull.py` CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,15 @@ poetry install
 This is a library for package management, and ensures a smoother experience than: ``pip install -r requirements.txt``
 
 8.  You are ready to interact with the package.
-    The following pulls GME, AMC and TSLA and filters returns the tickers
-    that have doubled in value within 5 consecutive days in 2021:
+    The following pulls GME, AMC and TSLA and returns only the tickers
+    that have doubled in value within 5 consecutive days in 2021.
+    The historical price data of the returned tickers is written to the `./ticker_data` dir.
 
 ```
-poetry run python -c "from q4_majorshortsqueezes.api.pull_data import main; main(["GME", "AMC", "TSLA"], "2020-01-01", ["q4_majorshortsqueezes.filter/double_price_within_a_week"])"
+poetry run python bin/pull_data.py --tickers GME AMC TSLA --start-date "2020-01-01" --filters "q4_majorshortsqueezes.filter/double_price_within_a_week" --output-path ./ticker_data
+```
+
+For help messages use the `-h` option:
+```
+poetry run python bin/pull_data.py -h
 ```

--- a/bin/pull_data.py
+++ b/bin/pull_data.py
@@ -1,0 +1,74 @@
+# TODO: Setup a python shebang that work with poetry interpreters across users
+import argparse
+import logging
+import os
+
+from q4_majorshortsqueezes.api import pull_data
+from q4_majorshortsqueezes import filter
+
+
+def dir_path(path):
+    if not os.path.exists(path):
+        raise argparse.ArgumentTypeError(f"{path} does not exist")
+
+    if not os.path.isdir(path):
+        raise argparse.ArgumentTypeError(f"{path} is not a valid dir")
+
+    return path
+
+
+def create_arg_parser():
+    parser = argparse.ArgumentParser(
+        description="Pull data for all given tickers and write the price data into files for "
+                    "the tickers that satisfy all filter criteria.",
+        formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument("--tickers", nargs='+', required=True,
+                        help="List of tickers to pull and analyze.")
+    parser.add_argument("--start-date", default=None,
+                        help="The start date for analyzing ticker data. "
+                             f"By default the max available date range is used.")
+    parser.add_argument("--filters", nargs='+', default=[],
+                        help="A list of Python paths to python functions which each adhere to the "
+                             "this interface: `List[Callable[[TickerHistory], bool]`.\n"
+                             "The path format for a criterion function is: "
+                             "`full.qualified.path.to.module/func_name`.\n\n"
+                             "Predefined filters are available under: "
+                             f"`{filter.__name__}`.\n\n"
+                             "To filter for tickers that have in the past doubled their "
+                             "value in 5 consecutive trading dates use this predefined filter:\n"
+                             f"`{filter.__name__}.double_price_within_a_week`.")
+
+    parser.add_argument("--output-path", required=True, type=dir_path,
+                        help="The script serializes the ticker price history data to this path.\n"
+                             "The file are stored as `csv` with the following naming scheme: "
+                             "`<ticker_name>.csv`.\n"
+                             "Careful! The script will override existing files!")
+    return parser
+
+
+def main():
+    logging.basicConfig(format='%(asctime)s - %(message)s', level=logging.INFO)
+
+    parser = create_arg_parser()
+    args = parser.parse_args()
+
+    logging.info("Tickers: `%s`", ", ".join(args.tickers))
+    logging.info("Start date: `%s`", args.start_date)
+    logging.info("Filters: `%s`", " ".join(args.filters))
+    logging.info("Output path: `%s`", args.output_path)
+
+    logging.info("Start pulling and filtering tickers.")
+    filtered_tickers = pull_data.main(args.tickers, args.start_date, args.filters)
+    logging.info("Finished pulling and filtering tickers.")
+    logging.info(f"The following tickers satisfied all filters: `%s`",
+                 ", ".join(filtered_tickers.keys()))
+
+    logging.info("Storing their historical price data now under: `%s`", args.output_path)
+    for ticker, ticker_history in filtered_tickers.items():
+        file_path = os.path.join(args.output_path, f"{ticker}.csv")
+        with open(file_path, mode="w") as fd:
+            ticker_history.to_csv(fd)
+
+
+if __name__ == "__main__":
+    main()

--- a/q4_majorshortsqueezes/api/pull_data.py
+++ b/q4_majorshortsqueezes/api/pull_data.py
@@ -5,13 +5,14 @@ from q4_majorshortsqueezes.ticker import load_ticker_history, TickerContainer, T
 from typing import Callable, Dict, List, Optional
 
 
-def main(tickers: Optional[List[str]], start_date: str, criterion_paths: List[str]) \
+def main(tickers: Optional[List[str]], start_date: Optional[str], criterion_paths: List[str]) \
         -> Dict[str, TickerHistory]:
     """Pull data for all given tickers and return the ones that satisfy all filter criteria.
 
     Args:
         tickers: A list of tickers, e.g, ["GME", "AMC", "SPY"].
         start_date: The start date in the form YYYY-MM-DD.
+                    If `None` is given the max date range will be used.
         criterion_paths: Python paths to python functions which each adhere to the
                          this interface: `List[Callable[[TickerHistory], bool]`.
                          The path format for a criterion function is:

--- a/q4_majorshortsqueezes/ticker.py
+++ b/q4_majorshortsqueezes/ticker.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import yfinance as yf
 
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 
 """
 A Panda's data frame with columns:
@@ -30,20 +30,17 @@ class TickerContainer:
         return self.__stored_tickers
 
 
-def load_ticker_history(ticker: str, start_date: str) -> TickerHistory:
+def load_ticker_history(ticker: str, start_date: Optional[str]) -> TickerHistory:
     """Loads a ticker data from Yahoo Finance, adds a data index column data_id and Open-Close High/Low columns.
-
-    This code was taken from:
-    https://github.com/GamestonkTerminal/GamestonkTerminal/blob/main/gamestonk_terminal/technical_analysis/trendline_api.py#L9
 
     Args:
         ticker: The stock ticker.
         start_date: Start date to load stock ticker data formatted YYYY-MM-DD.
+                    If `None` is given the max date range will be used.
 
     Returns:
         A Panda's data frame with columns Open, High, Low, Close, Adj Close, Volume, date_id, OC-High, OC-Low.
     """
-    # print(f"Start date: {start_date}")
     df_data = yf.download(ticker, start=start_date, progress=False)
 
     df_data["date_id"] = (df_data.index.date - df_data.index.date.min()).astype(


### PR DESCRIPTION
The newly added CLI makes the already existing data pull
functionalities from the python API available on the command line.

Features:
 - Pull any given amount of tickers via the `yfinance` package.
 - Specify filter criteria which work on a tickers historical data
   price data. The filters can be added dynamically and allows any
   number of filters.
 - Define a start data for historical data or use the max range.
 - Store the historical price data of the filtered tickers to `csv`
   files for further inspection.

**Testing**
Unit and integration tests:
```
$ poetry run python -m pytest -m "not integration_test" test/
...
===================== 7 passed in 1.42s =====================
```

Manual test of the CLI:
```
$ poetry run python bin/pull_data.py \
   --tickers GME AMC TSLA \
   --start-date "2020-01-01" \
   --filters "q4_majorshortsqueezes.filter/double_price_within_a_week" \
   --output-path ./ticker_data
...
The following tickers satisfied all filters: `GME, AMC`
```