### PR TITLE
Write ticker data to csv directly after downloading

### DIFF
--- a/bin/pull_data.py
+++ b/bin/pull_data.py
@@ -108,16 +108,11 @@ def main():
     filtered_tickers = pull_data.main(tickers=tickers,
                                       start_date=args.start_date,
                                       criterion_paths=args.filters,
-                                      csv_dir_path=args.ticker_source_dir)
+                                      csv_dir_path=args.ticker_source_dir,
+                                      csv_output_dir_path=args.output_path)
     logging.info("Finished pulling and filtering tickers.")
     logging.info(f"The following tickers satisfied all filters: `%s`",
-                 ", ".join(filtered_tickers.keys()))
-    # Store results
-    logging.info("Storing their historical price data now under: `%s`", args.output_path)
-    for ticker, ticker_history in filtered_tickers.items():
-        file_path = os.path.join(args.output_path, f"{ticker}.csv")
-        with open(file_path, mode="w") as fd:
-            ticker_history.to_csv(fd)
+                 ", ".join(filtered_tickers.get_tickers()))
 
 
 if __name__ == "__main__":

--- a/q4_majorshortsqueezes/filter.py
+++ b/q4_majorshortsqueezes/filter.py
@@ -131,6 +131,6 @@ def multiply_price_within_x_days(ticker_history: TickerHistory, multiplier: int,
 """
 The following filter implements the requested short squeeze filter:
 `definition of a major short squeeze is when a stock doubles in price (or more) within one week`.
-This function is compliant with the criterion interface of `ticker.TickerContainer.`
+This function is compliant with the criterion interface of `ticker.InMemoryTickerContainer.`
 """
 double_price_within_a_week = functools.partial(multiply_price_within_x_days, multiplier=2, days=5)

--- a/test/q4_majorshortsqueezes/api/test_pull_data.py
+++ b/test/q4_majorshortsqueezes/api/test_pull_data.py
@@ -2,6 +2,7 @@ import pytest
 from unittest import mock
 
 from q4_majorshortsqueezes.api.pull_data import main
+from q4_majorshortsqueezes.ticker import FileBackedTicketContainer
 
 
 @pytest.mark.integration_test
@@ -10,7 +11,7 @@ def test_main_download_data():
                   start_date="2020-01-01",
                   criterion_paths=["q4_majorshortsqueezes.filter/double_price_within_a_week"])
 
-    assert list(result) == ["AMC", "GME"]
+    assert result.get_tickers() == ["AMC", "GME"]
 
 
 def test_main_use_csv_data(ticker_sample_data_dir):
@@ -22,4 +23,19 @@ def test_main_use_csv_data(ticker_sample_data_dir):
                       criterion_paths=["q4_majorshortsqueezes.filter/double_price_within_a_week"],
                       csv_dir_path=ticker_sample_data_dir)
 
-    assert list(result) == ["AMC", "GME"]
+    assert result.get_tickers() == ["AMC", "GME"]
+
+
+def test_main_use_and_store_csv_data(ticker_sample_data_dir, tmpdir):
+    # Disable downloading and ensure we load the data from csv
+    with mock.patch("q4_majorshortsqueezes.api.pull_data.load_ticker_history") as m:
+        m.side_effect = RuntimeError("The ticker should be loaded via a csv file.")
+        result = main(tickers={"GME", "AMC", "TSLA"},
+                      start_date="2020-01-01",
+                      criterion_paths=[],
+                      csv_dir_path=ticker_sample_data_dir,
+                      csv_output_dir_path=tmpdir)
+
+    assert isinstance(result, FileBackedTicketContainer)
+    assert result.ticker_data_dir_path == tmpdir
+    assert result.get_tickers() == ["AMC", "GME", "TSLA"]

--- a/test/q4_majorshortsqueezes/test_ticker.py
+++ b/test/q4_majorshortsqueezes/test_ticker.py
@@ -4,17 +4,18 @@ import pytest
 from unittest.mock import MagicMock
 
 from q4_majorshortsqueezes.ticker import (
+    FileBackedTicketContainer,
     load_ticker_history,
     load_ticker_history_from_csv,
     retrieve_tickers_with_get_all_tickers_package,
-    TickerContainer,
+    InMemoryTickerContainer,
     TickerHistory,
 )
 
 
-class TestTickerContainer:
+class TestInMemoryTickerContainer:
     def test_add_with_single_criterion(self):
-        container = TickerContainer()
+        container = InMemoryTickerContainer()
         ticker_history1 = MagicMock(spec=TickerHistory)
         ticker_history1.__len__.side_effect = lambda: 10
         ticker_history2 = MagicMock(spec=TickerHistory)
@@ -24,10 +25,10 @@ class TestTickerContainer:
         container.store_ticker("A", ticker_history1)
         container.store_ticker("B", ticker_history2)
 
-        assert container.get_stored_tickers() == {"A": ticker_history1}
+        assert container.get_data() == {"A": ticker_history1}
 
     def test_add_with_multiple_criteria(self):
-        container = TickerContainer()
+        container = InMemoryTickerContainer()
         ticker_history1 = MagicMock(spec=TickerHistory)
         ticker_history1.__len__.side_effect = lambda: 10
         ticker_history2 = MagicMock(spec=TickerHistory)
@@ -41,7 +42,29 @@ class TestTickerContainer:
         container.store_ticker("B", ticker_history2)
         container.store_ticker("C", ticker_history3)
 
-        assert container.get_stored_tickers() == {"B": ticker_history2}
+        assert container.get_data() == {"B": ticker_history2}
+
+
+class TestFileBackedTicketContainer:
+    def test_attach_to_existing_dir(self, ticker_sample_data_dir):
+        container = FileBackedTicketContainer(ticker_sample_data_dir)
+
+        assert container.get_tickers() == ["AMC", "GME", "TSLA"]
+
+    def test_add_without_any_filter_criteria(self, ticker_sample_data_dir, tmpdir):
+        sample_data_container = FileBackedTicketContainer(ticker_sample_data_dir)
+
+        new_container = FileBackedTicketContainer(tmpdir)
+        for ticker, ticker_history in sample_data_container.get_data().items():
+            new_container.store_ticker(ticker, ticker_history)
+
+        tickers = new_container.get_tickers()
+        assert len(tickers) > 0
+        assert tickers == sample_data_container.get_tickers()
+        # TODO: For some reason loading and storing the panda data as csv yields different results.
+        #  This may indicate a bug.
+        ticker = tickers[0]
+        assert len(new_container.get_data()[ticker]) == len(sample_data_container.get_data()[ticker])
 
 
 @pytest.mark.integration_test


### PR DESCRIPTION
By persisting the ticker data on the fly we can
keep the memory consumption low.

**Testing**
Unit and integration tests:
```
$ poetry run python -m pytest test/
...
=============== 13 passed, 1 xfailed in 14.15s ===============
```