### PR TITLE
Make `get_tickers_fixed.py` distinguish ecxchanges

### DIFF
--- a/bin/pull_data.py
+++ b/bin/pull_data.py
@@ -35,7 +35,7 @@ def create_arg_parser():
                         help="Pull all nasdaq tickers.")
     parser.add_argument("--amex", action="store_true",
                         help="Pull all amex tickers.")
-    parser.add_argument("--min-market-cap",
+    parser.add_argument("--min-market-cap", default="0",
                         help="Minimum market cap of tickers (in million USD). "
                              "This does not apply to tickers set with `--tickers`.")
     parser.add_argument("--ticker-source-dir", type=dir_path, default=None,
@@ -76,16 +76,16 @@ def determine_tickers(args: argparse.Namespace) -> Set[str]:
                                                                 amex=args.amex,
                                                                 min_market_cap=int(args.min_market_cap))
         logging.info("Retrieved %s ticker symbols.", len(tickers))
-        logging.debug("Retrieved ticker symbols: %s", ", ".join(tickers))
+        logging.debug("Retrieved ticker symbols: %s", ", ".join(sorted(tickers)))
     else:
         if args.min_market_cap:
             logging.warning("Option `--min-market-cap` has no effect. "
-                            "Need to set at lesat one of the following options: "
+                            "Need to set at least one of the following options: "
                             "`--nyse`, `--nasdaq`, `--amex`")
 
     tickers = tickers.union(set(args.tickers))
     logging.info("%s tickers to process.", len(tickers))
-    logging.debug("List of tickers to process: %s", ", ".join(tickers))
+    logging.debug("List of tickers to process: %s", ", ".join(sorted(tickers)))
     return tickers
 
 


### PR DESCRIPTION
The supposed 'sane' module taken from this issue [1] is broken. It
always returns all tickers even if only a single exchange is selected.

This commit fixes this problem by using the implementation from this
pull request [2].

[1] https://github.com/shilewenuw/get_all_tickers/issues/12
[2] https://github.com/shilewenuw/get_all_tickers/pull/17/commits

**Testing**
Unit and integration tests:
```
$ poetry run python -m pytest test/
...
========== 12 passed, 2 xfailed, 3 warnings in 6.85s ===========
```

Manually pulling the tickers with the API per exchange. The
ticker count return for the different exchanges is now:
 - NYSE: 2671
 - NASDAQ: 4249
 - AMEX: 252
 - All enabled: 7172